### PR TITLE
Overload `__getattribute__` in the pipeline

### DIFF
--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -262,6 +262,7 @@ def run_after(stage):
        Add the ability to define post-init hooks in tests.
 
     '''
+    stage = stage if stage != 'init' else '__init__'
     return _runx('post_' + stage)
 
 

--- a/reframe/core/hooks.py
+++ b/reframe/core/hooks.py
@@ -24,9 +24,6 @@ def attach_hooks(hooks, name=None):
             phase = name
             if phase is None:
                 fn_name = func.__name__
-                if fn_name == '__init__':
-                    fn_name = 'init'
-
                 phase = kind + fn_name
             elif phase is not None and not phase.startswith(kind):
                 # Just any phase that does not exist
@@ -37,8 +34,6 @@ def attach_hooks(hooks, name=None):
 
             return [h for h in hooks[phase]
                     if h.__name__ not in obj._disabled_hooks]
-
-        func.__rfm_pipeline_fn__ = func
 
         @functools.wraps(func)
         def _fn(obj, *args, **kwargs):

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -13,7 +13,6 @@ __all__ = [
 ]
 
 
-import contextlib
 import functools
 import glob
 import inspect


### PR DESCRIPTION
- The `__getattribute__` method is the one doing the magic of calling the decorated function.

- I've also moved the special handling of the `init` stage into the `run_after` decorator, since this special treatment is also done in the `run_before` decorator. This simplifies a bit the `attach_hooks` function in `hooks.py` which I think it should not be aware of these special cases.