### PR TITLE
Use `affinity` instead of `ptile`

### DIFF
--- a/reframe/core/schedulers/lsf.py
+++ b/reframe/core/schedulers/lsf.py
@@ -52,7 +52,7 @@ class LsfJobScheduler(PbsJobScheduler):
 
         if job.num_cpus_per_task is not None:
             preamble.append(self._format_option(job.num_cpus_per_task,
-                                                '-R "span[ptile={0}]"'))
+                                                '-R "affinity[core({0})]"'))
 
         # add job time limit in minutes
         if job.time_limit is not None:

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -140,7 +140,7 @@ def _expected_lsf_directives(job):
         f'#BSUB -e {job.stderr}',
         f'#BSUB -nnodes {job.num_tasks // job.num_tasks_per_node}',
         f'#BSUB -W {int(job.time_limit // 60)}',
-        f'#BSUB -R "span[ptile={job.num_cpus_per_task}]"',
+        f'#BSUB -R "affinity[core({job.num_cpus_per_task})]"',
         f'#BSUB -x',
         f'#BSUB --account=spam',
         f'#BSUB --gres=gpu:4',


### PR DESCRIPTION
I spent some time thinking and have concluded that the `ptile` option is problematic. I have seen it defined in different ways but mainly as the number of slots per host that users want. I imagine this isn't what users would expect the `job.num_cpus_per_task` to mean in ReFrame. In this way, it isn't possible to specify multiple tasks per node that each have a subset of the node's cpus.

I found there is another option to `-R` called `affinity[core(<N>)]` that allows uses to specify number of cpus that should be bound to each MPI task. This solves the above issue and allows for hybrid MPI / shared mem jobs which wasn't possible with the current setup.

It also solves the last remaining issue of the main PR.